### PR TITLE
NEW: Add task definition for fslslice

### DIFF
--- a/pydra/tasks/fsl/__init__.py
+++ b/pydra/tasks/fsl/__init__.py
@@ -9,5 +9,12 @@ from .fast import FAST
 from .flirt import FLIRT, ApplyXFM, ConcatXFM, ConvertXFM, InvertXFM
 from .fnirt import FNIRT, ApplyWarp, ConvertWarp, InvWarp
 from .susan import SUSAN
-from .utils import (FSLROI, FSLInfo, FSLMerge, FSLReorient2Std, FSLSplit,
-                    fslmaths)
+from .utils import (
+    FSLROI,
+    FSLInfo,
+    FSLMerge,
+    FSLReorient2Std,
+    FSLSlice,
+    FSLSplit,
+    fslmaths,
+)

--- a/pydra/tasks/fsl/utils/__init__.py
+++ b/pydra/tasks/fsl/utils/__init__.py
@@ -3,4 +3,4 @@ from .fslinfo import FSLInfo
 from .fslmerge import FSLMerge
 from .fslreorient2std import FSLReorient2Std
 from .fslroi import FSLROI
-from .fslsplit import FSLSplit
+from .fslsplit import FSLSlice, FSLSplit

--- a/pydra/tasks/fsl/utils/fslsplit.py
+++ b/pydra/tasks/fsl/utils/fslsplit.py
@@ -4,20 +4,19 @@ FSLSplit
 
 Examples
 --------
->>> task = FSLSplit(input_image="input.nii")
+>>> task = FSLSplit(input_image="input.nii.gz")
 >>> task.cmdline
-'fslsplit input.nii vol -t'
+'fslsplit input.nii.gz input -t'
 
->>> task = FSLSplit(
+>>> task = FSLSlice(
 ...     input_image="volume.nii",
 ...     output_basename="slice",
-...     direction="z",
 ... )
 >>> task.cmdline
 'fslsplit volume.nii slice -z'
 """
 
-__all__ = ["FSLSplit"]
+__all__ = ["FSLSplit", "FSLSlice"]
 
 import os
 import pathlib
@@ -25,6 +24,16 @@ import pathlib
 import attrs
 
 import pydra
+
+
+def _get_output_basename(output_basename, input_image):
+    return output_basename or pathlib.PurePath(input_image).name.split(".", 1)[0]
+
+
+def _get_output_images(output_basename, input_image):
+    output_basename = _get_output_basename(output_basename, input_image)
+
+    return sorted(pathlib.Path.cwd().glob(f"{output_basename}*.*"))
 
 
 @attrs.define(slots=False, kw_only=True)
@@ -40,11 +49,10 @@ class FSLSplitSpec(pydra.specs.ShellSpec):
     )
 
     output_basename: str = attrs.field(
-        default="vol",
         metadata={
             "help_string": "output basename",
-            "argstr": "",
-        },
+            "formatter": _get_output_basename,
+        }
     )
 
     direction: str = attrs.field(
@@ -63,10 +71,8 @@ class FSLSplitOutSpec(pydra.specs.ShellOutSpec):
 
     output_images: pydra.specs.MultiOutputFile = attrs.field(
         metadata={
-            "help_string": "output splitted images",
-            "callable": lambda output_basename: (
-                sorted(pathlib.Path(pathlib.Path.cwd()).glob(f"{output_basename}*.*"))
-            ),
+            "help_string": "output images",
+            "callable": _get_output_images,
         }
     )
 
@@ -79,3 +85,29 @@ class FSLSplit(pydra.engine.ShellCommandTask):
     input_spec = pydra.specs.SpecInfo(name="FSLSplitInput", bases=(FSLSplitSpec,))
 
     output_spec = pydra.specs.SpecInfo(name="FSLSplitOutput", bases=(FSLSplitOutSpec,))
+
+
+@attrs.define(slots=False, kw_only=True)
+class FSLSliceSpec(FSLSplitSpec):
+    """Specifications for fslslice."""
+
+    direction: str = attrs.field(
+        default="z",
+        metadata={
+            "help_string": "split direction (z)",
+            "argstr": "-{direction}",
+            "allowed_values": {"z"},
+        },
+    )
+
+
+class FSLSliceOutSpec(FSLSplitOutSpec):
+    """Output specifications for fslslice."""
+
+
+class FSLSlice(FSLSplit):
+    """Task definition for fslslice."""
+
+    input_spec = pydra.specs.SpecInfo(name="FSLSliceInput", bases=(FSLSliceSpec,))
+
+    output_spec = pydra.specs.SpecInfo(name="FSLSliceOutput", bases=(FSLSliceOutSpec,))


### PR DESCRIPTION
Reuse the `FSLSplit` task definition instead of exposing `fslslice` which treats `output_basename` slightly differently. The end result looks the same on my tests.