### PR TITLE
[FIX] Add missing decorator to `Eddy` output specs

### DIFF
--- a/src/pydra/tasks/fsl/eddy/eddy.py
+++ b/src/pydra/tasks/fsl/eddy/eddy.py
@@ -258,6 +258,7 @@ class EddySpec(ShellSpec):
     verbose: bool = field(metadata={"help_string": "enable verbose logging", "argstr": "--verbose"})
 
 
+@define(slots=False, kw_only=True)
 class EddyOutSpec(ShellOutSpec):
     """Output specification for eddy."""
 


### PR DESCRIPTION
Hi @ghisvail 

When trying to use Eddy, I'm currently getting some AttributesErrors on `lzout` which, I think, are related to a missing decorator that this PR is proposing to add.
