### PR TITLE
[FIX] Make `Eddy` `fieldmap_image` optional

### DIFF
--- a/src/pydra/tasks/fsl/eddy/eddy.py
+++ b/src/pydra/tasks/fsl/eddy/eddy.py
@@ -66,7 +66,7 @@ class EddySpec(ShellSpec):
 
     bval_file: PathLike = field(metadata={"help_string": "diffusion weighting", "mandatory": True, "argstr": "--bvals"})
 
-    fieldmap_image: PathLike = field(metadata={"help_string": "fieldmap image", "mandatory": True, "argstr": "--field"})
+    fieldmap_image: PathLike = field(metadata={"help_string": "fieldmap image", "argstr": "--field"})
 
     fieldmap_matrix: PathLike = field(
         metadata={


### PR DESCRIPTION
The PR proposes to remove the mandatory nature of the `fieldmap_image` input for Eddy as the [FSL doc](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/eddy/UsersGuide) says it's optional:

```
--field=filename Name of image volume representing the susceptibility field.
Should be in Hz. Optional.
```