### PR TITLE
add threshold to fsl maths

### DIFF
--- a/src/pydra/tasks/fsl/maths.py
+++ b/src/pydra/tasks/fsl/maths.py
@@ -18,6 +18,10 @@ Multiply input image with a binary mask:
 >>> task = Mul(input_image="input.nii", other_image="mask.nii", output_image="output.nii")
 >>> task.cmdline
 'fslmaths input.nii -mul mask.nii output.nii'
+
+>>> task = Threshold(input_image="input.nii", threshold=0.3, output_image="output.nii")
+>>> task.cmdline
+'fslmaths input.nii -thr 0.3 output.nii'
 """
 
 __all__ = ["Maths", "MathsSpec", "Mul", "Threshold"]

--- a/src/pydra/tasks/fsl/maths.py
+++ b/src/pydra/tasks/fsl/maths.py
@@ -20,7 +20,7 @@ Multiply input image with a binary mask:
 'fslmaths input.nii -mul mask.nii output.nii'
 """
 
-__all__ = ["Maths", "MathsSpec", "Mul"]
+__all__ = ["Maths", "MathsSpec", "Mul", "Threshold"]
 
 from os import PathLike
 
@@ -78,6 +78,21 @@ class Mul(Maths):
     """Task definition for fslmaths' mul."""
 
     input_spec = SpecInfo(name="Input", bases=(MulSpec,))
+
+
+@define(kw_only=True)
+class ThresholdSpec(MathsSpec):
+    """Specifications for fslmaths' threshold."""
+
+    threshold: float = field(
+        metadata={"help_string": "value for thresholding the image", "mandatory": True, "argstr": "-thr"}
+    )
+
+
+class Threshold(Maths):
+    """Task definition for fslmaths' threshold."""
+
+    input_spec = SpecInfo(name="Input", bases=(ThresholdSpec,))
 
 
 # TODO: Drop compatibility alias for 0.x


### PR DESCRIPTION
This PR proposes to add [Threshold](https://nipype.readthedocs.io/en/0.12.0/interfaces/generated/nipype.interfaces.fsl.maths.html#threshold) to the fsl.maths module.

@ghisvail I might have missed something since the following is not producing the right command line:

```python
>>> from pydra.tasks import fsl
>>> t = fsl.maths.Threshold(threshold=0.0, input_image="toto.nii.gz", output_image="titi.nii.gz")
>>> t.cmdline
'fslmaths toto.nii.gz titi.nii.gz'
```

Command should be `'fslmaths toto.nii.gz -thr 0.0000 titi.nii.gz'